### PR TITLE
Implement fromBytes and toString for u256

### DIFF
--- a/assembly/integer/u128.ts
+++ b/assembly/integer/u128.ts
@@ -22,7 +22,7 @@ import {
   __divmod_rem,
 
 } from '../globals';
-import { utoa10, atou128 } from '../utils';
+import {atou128, u128toa10} from '../utils';
 
 // @external("u128.spec.as", "logStr")
 // declare function logStr(str: string): void;
@@ -898,7 +898,7 @@ export class u128 {
       }
       return result;
     } else if (radix == 10) {
-      return utoa10(this);
+      return u128toa10(this);
     }
 
     return "undefined";

--- a/assembly/integer/u128.ts
+++ b/assembly/integer/u128.ts
@@ -22,7 +22,7 @@ import {
   __divmod_rem,
 
 } from '../globals';
-import {atou128, u128toa10} from '../utils';
+import { atou128, u128toa10 } from '../utils';
 
 // @external("u128.spec.as", "logStr")
 // declare function logStr(str: string): void;

--- a/assembly/integer/u256.ts
+++ b/assembly/integer/u256.ts
@@ -1,17 +1,32 @@
-import { LOAD, STORE } from 'internal/arraybuffer';
+import { LOAD } from 'internal/arraybuffer';
 
 import { i128 } from './i128';
 import { u128 } from './u128';
-import {u256toa10, utoa10} from "../utils";
+import { u256toa10 } from "../utils";
 
 const HEX_CHARS = '0123456789abcdef';
 
 export class u256 {
 
-  @inline static get Zero(): u256 { return new u256(); }
-  @inline static get One():  u256 { return new u256(1); }
-  @inline static get Min():  u256 { return new u256(); }
-  @inline static get Max():  u256 { return new u256(u64.MAX_VALUE, u64.MAX_VALUE, u64.MAX_VALUE, u64.MAX_VALUE); }
+  @inline
+  static get Zero(): u256 {
+    return new u256();
+  }
+
+  @inline
+  static get One(): u256 {
+    return new u256(1);
+  }
+
+  @inline
+  static get Min(): u256 {
+    return new u256();
+  }
+
+  @inline
+  static get Max(): u256 {
+    return new u256(u64.MAX_VALUE, u64.MAX_VALUE, u64.MAX_VALUE, u64.MAX_VALUE);
+  }
 
   @inline
   static fromU256(value: u256): u256 {
@@ -67,10 +82,10 @@ export class u256 {
     assert(array.length && (array.length & 31) == 0);
     var buffer = <ArrayBuffer>array.buffer_;
     return new u256(
-        LOAD<u64>(buffer, 0),
-        LOAD<u64>(buffer, 1),
-        LOAD<u64>(buffer, 2),
-        LOAD<u64>(buffer, 3),
+      LOAD<u64>(buffer, 0),
+      LOAD<u64>(buffer, 1),
+      LOAD<u64>(buffer, 2),
+      LOAD<u64>(buffer, 3),
     );
   }
 
@@ -78,10 +93,10 @@ export class u256 {
     assert(array.length && (array.length & 31) == 0);
     var buffer = <ArrayBuffer>array.buffer_;
     return new u256(
-        bswap<u64>(LOAD<u64>(buffer, 3)),
-        bswap<u64>(LOAD<u64>(buffer, 2)),
-        bswap<u64>(LOAD<u64>(buffer, 1)),
-        bswap<u64>(LOAD<u64>(buffer, 0))
+      bswap<u64>(LOAD<u64>(buffer, 3)),
+      bswap<u64>(LOAD<u64>(buffer, 2)),
+      bswap<u64>(LOAD<u64>(buffer, 1)),
+      bswap<u64>(LOAD<u64>(buffer, 0))
     );
   }
 
@@ -107,7 +122,8 @@ export class u256 {
     public lo2: u64 = 0,
     public hi1: u64 = 0,
     public hi2: u64 = 0,
-  ) {}
+  ) {
+  }
 
   @inline
   set(value: u256): this {
@@ -188,11 +204,11 @@ export class u256 {
   @inline @operator.prefix('-')
   neg(): u256 {
     var lo1 = ~this.lo1,
-        lo2 = ~this.lo2,
-        hi1 = ~this.hi1,
-        hi2 = ~this.hi2;
+      lo2 = ~this.lo2,
+      hi1 = ~this.hi1,
+      hi2 = ~this.hi2;
 
-    var cy  = ((lo1 & 1) + (lo1 >> 1)) >> 63;
+    var cy = ((lo1 & 1) + (lo1 >> 1)) >> 63;
     var cy1 = ((lo2 & 1) + (lo2 >> 1)) >> 63;
     var cy2 = ((hi1 & 1) + (hi1 >> 1)) >> 63;
 
@@ -201,13 +217,13 @@ export class u256 {
 
   @inline @operator('+')
   static add(a: u256, b: u256): u256 {
-    var alo  = a.lo1;
-    var blo  = b.lo1;
-    var lo   = new u128(alo) + new u128(blo);
+    var alo = a.lo1;
+    var blo = b.lo1;
+    var lo = new u128(alo) + new u128(blo);
     var amid = new u128(alo, a.hi1);
     var bmid = new u128(blo, b.hi1);
-    var mid  = amid + bmid + new u128(lo.hi);
-    var hi   = a.hi2 + b.hi2 + mid.hi;
+    var mid = amid + bmid + new u128(lo.hi);
+    var hi = a.hi2 + b.hi2 + mid.hi;
 
     return new u256(lo.lo, mid.lo, mid.hi, hi);
   }
@@ -229,80 +245,80 @@ export class u256 {
 
   @inline @operator('>>')
   static shr(value: u256, shift: i32): u256 {
-      shift &= 255;
+    shift &= 255;
 
-      // need for preventing redundant i32 -> u64 extends
-      var shift64 = shift as u64;
-      let lo1: u64, lo2: u64, hi1: u64, hi2: u64;
+    // need for preventing redundant i32 -> u64 extends
+    var shift64 = shift as u64;
+    let lo1: u64, lo2: u64, hi1: u64, hi2: u64;
 
-      if (shift64 <= 64) {
-          hi2 = value.hi2 >> shift64;
-          hi1 = (value.hi1 >> shift64) | (hi2 << (64 - shift64));
-          lo2 = (value.lo2 >> shift64) | (hi1 << (64 - shift64));
-          lo1 = (value.lo1 >> shift64) | (lo2 << (64 - shift64));
-          return new u256(lo1, lo2, hi1, hi2);
-      } else if (shift64 > 64 && shift64 <= 128) {
-          hi1 = value.hi2 >> (128 - shift64);
-          return new u256(value.lo2, value.hi1, hi1, 0);
-      } else if (shift64 > 128 && shift64 <= 192) {
-          lo2 = value.hi2 >> (192 - shift64);
-          return new u256(value.hi1, lo2, 0, 0);
-      } else {
-          return new u256(value.hi2 >> (256 - shift64), 0, 0, 0);
-      }
+    if (shift64 <= 64) {
+      hi2 = value.hi2 >> shift64;
+      hi1 = (value.hi1 >> shift64) | (hi2 << (64 - shift64));
+      lo2 = (value.lo2 >> shift64) | (hi1 << (64 - shift64));
+      lo1 = (value.lo1 >> shift64) | (lo2 << (64 - shift64));
+      return new u256(lo1, lo2, hi1, hi2);
+    } else if (shift64 > 64 && shift64 <= 128) {
+      hi1 = value.hi2 >> (128 - shift64);
+      return new u256(value.lo2, value.hi1, hi1, 0);
+    } else if (shift64 > 128 && shift64 <= 192) {
+      lo2 = value.hi2 >> (192 - shift64);
+      return new u256(value.hi1, lo2, 0, 0);
+    } else {
+      return new u256(value.hi2 >> (256 - shift64), 0, 0, 0);
+    }
   }
 
   @inline @operator('>>>')
   static shr_u(value: u256, shift: i32): u256 {
-      return u256.shr(value, shift);
+    return u256.shr(value, shift);
   }
 
   @inline @operator('==')
   static eq(a: u256, b: u256): bool {
-      return a.hi2 == b.hi2 && a.hi1 == b.hi1 && a.lo2 == b.lo2 && a.lo1 == b.lo1;
+    return a.lo1 == b.lo1 && a.lo2 == b.lo2 && a.hi1 == b.hi1 && a.hi2 == b.hi2;
   }
 
   @inline @operator('!=')
   static ne(a: u256, b: u256): bool {
-      return !u256.eq(a, b);
+    return !u256.eq(a, b);
   }
 
   @inline @operator('<')
   static lt(a: u256, b: u256): bool {
-      var ah2 = a.hi2, ah1 = a.hi1, bh2 = b.hi2, bh1 = b.hi1, al2 = a.lo2, bl2 = b.lo2;
-      if (ah2 == bh2) {
-          if (ah1 == bh1) {
-              if (al2 == bl2) {
-                  return a.lo1 < b.lo1;
-              } else {
-                  return al2 < bl2;
-              }
-          } else {
-              return ah1 < bh1;
-          }
+    var ah2 = a.hi2, ah1 = a.hi1, bh2 = b.hi2, bh1 = b.hi1, al2 = a.lo2, bl2 = b.lo2;
+    if (ah2 == bh2) {
+      if (ah1 == bh1) {
+        if (al2 == bl2) {
+          return a.lo1 < b.lo1;
+        } else {
+          return al2 < bl2;
+        }
       } else {
-          return ah2 < bh2;
+        return ah1 < bh1;
       }
+    } else {
+      return ah2 < bh2;
+    }
   }
 
   @inline @operator('>')
   static gt(a: u256, b: u256): bool {
-      return b < a;
+    return b < a;
   }
 
   @inline @operator('<=')
   static le(a: u256, b: u256): bool {
-      return !u256.gt(a, b);
+    return !u256.gt(a, b);
   }
 
   @inline @operator('>=')
   static ge(a: u256, b: u256): bool {
-      return !u256.lt(a, b);
+    return !u256.lt(a, b);
   }
 
   @inline
   static popcnt(value: u256): i32 {
-    var count             = popcnt(value.lo1);
+    var count = popcnt(value.lo1);
     if (value.lo2) count += popcnt(value.lo2);
     if (value.hi1) count += popcnt(value.hi1);
     if (value.hi2) count += popcnt(value.hi2);
@@ -311,46 +327,46 @@ export class u256 {
 
   @inline
   static clz(value: u256): i32 {
-         if (value.hi2) return <i32>(clz(value.hi2) + 0);
+    if (value.hi2) return <i32>(clz(value.hi2) + 0);
     else if (value.hi1) return <i32>(clz(value.hi1) + 64);
     else if (value.lo2) return <i32>(clz(value.lo2) + 128);
-    else                return <i32>(clz(value.lo1) + 192);
+    else return <i32>(clz(value.lo1) + 192);
   }
 
   @inline
   static ctz(value: u256): i32 {
-         if (value.lo1) return <i32>(ctz(value.lo1) + 0);
+    if (value.lo1) return <i32>(ctz(value.lo1) + 0);
     else if (value.lo2) return <i32>(ctz(value.lo2) + 64);
     else if (value.hi1) return <i32>(ctz(value.hi1) + 128);
-    else                return <i32>(ctz(value.hi2) + 192);
+    else return <i32>(ctz(value.hi2) + 192);
   }
 
   /**
-  * Convert to 128-bit signed integer
-  * @return 256-bit signed integer
-  */
+   * Convert to 128-bit signed integer
+   * @return 256-bit signed integer
+   */
   @inline
   toI128(): i128 {
     return new i128(
-       this.lo1,
+      this.lo1,
       (this.lo2 & 0x7FFFFFFFFFFFFFFF) |
       (this.hi2 & 0x8000000000000000)
     );
   }
 
   /**
-  * Convert to 128-bit unsigned integer
-  * @return 128-bit unsigned integer
-  */
+   * Convert to 128-bit unsigned integer
+   * @return 128-bit unsigned integer
+   */
   @inline
   toU128(): u128 {
     return new u128(this.lo1, this.lo2);
   }
 
   /**
-  * Convert to 64-bit signed integer
-  * @return 64-bit signed integer
-  */
+   * Convert to 64-bit signed integer
+   * @return 64-bit signed integer
+   */
   @inline
   toI64(): i64 {
     return <i64>(
@@ -360,36 +376,36 @@ export class u256 {
   }
 
   /**
-  * Convert to 64-bit unsigned integer
-  * @return 64-bit unsigned integer
-  */
+   * Convert to 64-bit unsigned integer
+   * @return 64-bit unsigned integer
+   */
   @inline
   toU64(): u64 {
     return this.lo1;
   }
 
   /**
-  * Convert to 32-bit signed integer
-  * @return 32-bit signed integer
-  */
+   * Convert to 32-bit signed integer
+   * @return 32-bit signed integer
+   */
   @inline
   toI32(): i32 {
     return <i32>this.toI64();
   }
 
   /**
-  * Convert to 32-bit unsigned integer
-  * @return 32-bit unsigned integer
-  */
+   * Convert to 32-bit unsigned integer
+   * @return 32-bit unsigned integer
+   */
   @inline
   toU32(): u32 {
     return <u32>this.lo1;
   }
 
   /**
-  * Convert to 1-bit boolean
-  * @return 1-bit boolean
-  */
+   * Convert to 1-bit boolean
+   * @return 1-bit boolean
+   */
   @inline
   toBool(): bool {
     return <bool>(this.lo1 | this.lo2 | this.hi1 | this.hi2);
@@ -405,16 +421,16 @@ export class u256 {
     var hi2 = this.hi2, lo2 = this.lo2;
 
     var result: u8[] = [
-      <u8>(lo1 >>  0), <u8>(lo1 >>  8), <u8>(lo1 >> 16), <u8>(lo1 >> 24),
+      <u8>(lo1 >> 0), <u8>(lo1 >> 8), <u8>(lo1 >> 16), <u8>(lo1 >> 24),
       <u8>(lo1 >> 32), <u8>(lo1 >> 40), <u8>(lo1 >> 48), <u8>(lo1 >> 56),
 
-      <u8>(lo2 >>  0), <u8>(lo2 >>  8), <u8>(lo2 >> 16), <u8>(lo2 >> 24),
+      <u8>(lo2 >> 0), <u8>(lo2 >> 8), <u8>(lo2 >> 16), <u8>(lo2 >> 24),
       <u8>(lo2 >> 32), <u8>(lo2 >> 40), <u8>(lo2 >> 48), <u8>(lo2 >> 56),
 
-      <u8>(hi1 >>  0), <u8>(hi1 >>  8), <u8>(hi1 >> 16), <u8>(hi1 >> 24),
+      <u8>(hi1 >> 0), <u8>(hi1 >> 8), <u8>(hi1 >> 16), <u8>(hi1 >> 24),
       <u8>(hi1 >> 32), <u8>(hi1 >> 40), <u8>(hi1 >> 48), <u8>(hi1 >> 56),
 
-      <u8>(hi2 >>  0), <u8>(hi2 >>  8), <u8>(hi2 >> 16), <u8>(hi2 >> 24),
+      <u8>(hi2 >> 0), <u8>(hi2 >> 8), <u8>(hi2 >> 16), <u8>(hi2 >> 24),
       <u8>(hi2 >> 32), <u8>(hi2 >> 40), <u8>(hi2 >> 48), <u8>(hi2 >> 56),
     ];
 
@@ -427,16 +443,16 @@ export class u256 {
 
     var result: u8[] = [
       <u8>(hi2 >> 56), <u8>(hi2 >> 48), <u8>(hi2 >> 40), <u8>(hi2 >> 32),
-      <u8>(hi2 >> 24), <u8>(hi2 >> 16), <u8>(hi2 >>  8), <u8>(hi2 >>  0),
+      <u8>(hi2 >> 24), <u8>(hi2 >> 16), <u8>(hi2 >> 8), <u8>(hi2 >> 0),
 
       <u8>(hi1 >> 56), <u8>(hi1 >> 48), <u8>(hi1 >> 40), <u8>(hi1 >> 32),
-      <u8>(hi1 >> 24), <u8>(hi1 >> 16), <u8>(hi1 >>  8), <u8>(hi1 >>  0),
+      <u8>(hi1 >> 24), <u8>(hi1 >> 16), <u8>(hi1 >> 8), <u8>(hi1 >> 0),
 
       <u8>(lo2 >> 56), <u8>(lo2 >> 48), <u8>(lo2 >> 40), <u8>(lo2 >> 32),
-      <u8>(lo2 >> 24), <u8>(lo2 >> 16), <u8>(lo2 >>  8), <u8>(lo2 >>  0),
+      <u8>(lo2 >> 24), <u8>(lo2 >> 16), <u8>(lo2 >> 8), <u8>(lo2 >> 0),
 
       <u8>(lo1 >> 56), <u8>(lo1 >> 48), <u8>(lo1 >> 40), <u8>(lo1 >> 32),
-      <u8>(lo1 >> 24), <u8>(lo1 >> 16), <u8>(lo1 >>  8), <u8>(lo1 >>  0),
+      <u8>(lo1 >> 24), <u8>(lo1 >> 16), <u8>(lo1 >> 8), <u8>(lo1 >> 0),
     ];
 
     return result;
@@ -458,9 +474,9 @@ export class u256 {
     if (radix == 16) {
       let shift: i32 = 252 - (u256.clz(it) & ~3);
       while (shift >= 0) {
-        it     >>= shift;
+        it >>= shift;
         result = result.concat(HEX_CHARS.charAt(<i32>(it.lo1 & 15)));
-        shift  -= 4;
+        shift -= 4;
       }
       return result;
     } else if (radix == 10) {

--- a/assembly/integer/u256.ts
+++ b/assembly/integer/u256.ts
@@ -251,17 +251,17 @@ export class u256 {
     var shift64 = shift as u64;
     let lo1: u64, lo2: u64, hi1: u64, hi2: u64;
 
-    if (shift64 <= 64) {
+    if (shift <= 64) {
       hi2 = value.hi2 >> shift64;
       hi1 = (value.hi1 >> shift64) | (hi2 << (64 - shift64));
       lo2 = (value.lo2 >> shift64) | (hi1 << (64 - shift64));
       lo1 = (value.lo1 >> shift64) | (lo2 << (64 - shift64));
       return new u256(lo1, lo2, hi1, hi2);
-    } else if (shift64 > 64 && shift64 <= 128) {
+    } else if (shift > 64 && shift <= 128) {
       hi1 = value.hi2 >> (128 - shift64);
       return new u256(value.lo2, value.hi1, hi1, 0);
-    } else if (shift64 > 128 && shift64 <= 192) {
-      lo2 = value.hi2 >> (192 - shift64);
+    } else if (shift > 128 && shift <= 192) {
+      lo2 = value.hi2 >> (192 - shift);
       return new u256(value.hi1, lo2, 0, 0);
     } else {
       return new u256(value.hi2 >> (256 - shift64), 0, 0, 0);

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -131,7 +131,7 @@ function processU64(digits: Int8Array, value: u64): void {
   }
 }
 
-export function utoa10(value: u128): string {
+export function u128toa10(value: u128): string {
   var length = 40;
   var digits = new Int8Array(length);
 

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -138,32 +138,6 @@ export function utoa10(value: u128): string {
   processU64(digits, value.hi);
   processU64(digits, value.lo);
 
-  // for (let i = 63; i != -1; i--) {
-  //   let left_bit = value.hi & (1 << i) ? 1 : 0;
-  //   for (let digit_index = 0; digit_index < length; digit_index++) {
-  //     digits[digit_index] += digits[digit_index] >= 5 ? 3 : 0;
-  //   }
-  //   for (let j = length - 1; j != -1; j--) {
-  //     digits[j] <<= 1;
-  //     if (j < length - 1) digits[j + 1] |= digits[j] > 15 ? 1 : 0;
-  //     digits[j] &= 15;
-  //   }
-  //   digits[0] += <u8>left_bit;
-  // }
-  //
-  // for (let i = 63; i != -1; i--) {
-  //   let left_bit = value.lo & (1 << i) ? 1 : 0;
-  //   for (let digit_index = 0; digit_index < length; digit_index++) {
-  //     digits[digit_index] += digits[digit_index] >= 5 ? 3 : 0;
-  //   }
-  //   for (let j = length - 1; j != -1; j--) {
-  //     digits[j] <<= 1;
-  //     if (j < length - 1) digits[j + 1] |= digits[j] > 15 ? 1 : 0;
-  //     digits[j] &= 15;
-  //   }
-  //   digits[0] += <u8>left_bit;
-  // }
-
   var result = "";
   var start = false;
   for (let digit_index = length-1; digit_index != -1; digit_index--) {

--- a/build/release/bignum.wat
+++ b/build/release/bignum.wat
@@ -192,6 +192,12 @@
  (export "u256.and" (func $assembly/integer/u256/u256.and))
  (export "u256.shr" (func $assembly/integer/u256/u256.shr))
  (export "u256.shr_u" (func $assembly/integer/u256/u256.shr))
+ (export "u256.eq" (func $assembly/integer/u256/u256.eq))
+ (export "u256.ne" (func $assembly/integer/u256/u256.ne))
+ (export "u256.lt" (func $assembly/integer/u256/u256.lt))
+ (export "u256.gt" (func $assembly/integer/u256/u256.gt))
+ (export "u256.le" (func $assembly/integer/u256/u256.le))
+ (export "u256.ge" (func $assembly/integer/u256/u256.ge))
  (export "u256.popcnt" (func $assembly/integer/u256/u256.popcnt))
  (export "u256.clz" (func $assembly/integer/u256/u256.clz))
  (export "u256.ctz" (func $assembly/integer/u256/u256.ctz))
@@ -308,7 +314,7 @@
   if
    i32.const 0
    i32.const 312
-   i32.const 197
+   i32.const 171
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -1751,7 +1757,7 @@
   if
    i32.const 0
    i32.const 936
-   i32.const 78
+   i32.const 93
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -1800,7 +1806,7 @@
   if
    i32.const 0
    i32.const 936
-   i32.const 67
+   i32.const 82
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -2023,7 +2029,309 @@
   end
   unreachable
  )
- (func $assembly/integer/u256/u256.popcnt (; 73 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.eq (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  i64.load
+  local.get $1
+  i64.load
+  i64.eq
+  local.tee $2
+  if
+   local.get $0
+   i64.load offset=8
+   local.get $1
+   i64.load offset=8
+   i64.eq
+   local.set $2
+  end
+  local.get $2
+  if
+   local.get $0
+   i64.load offset=16
+   local.get $1
+   i64.load offset=16
+   i64.eq
+   local.set $2
+  end
+  local.get $2
+  if
+   local.get $0
+   i64.load offset=24
+   local.get $1
+   i64.load offset=24
+   i64.eq
+   local.set $2
+  end
+  local.get $2
+ )
+ (func $assembly/integer/u256/u256.ne (; 74 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $2
+  i64.load
+  local.get $1
+  i64.load
+  i64.eq
+  local.tee $0
+  if
+   local.get $2
+   i64.load offset=8
+   local.get $1
+   i64.load offset=8
+   i64.eq
+   local.set $0
+  end
+  local.get $0
+  if
+   local.get $2
+   i64.load offset=16
+   local.get $1
+   i64.load offset=16
+   i64.eq
+   local.set $0
+  end
+  local.get $0
+  if
+   local.get $2
+   i64.load offset=24
+   local.get $1
+   i64.load offset=24
+   i64.eq
+   local.set $0
+  end
+  local.get $0
+  i32.eqz
+ )
+ (func $assembly/integer/u256/u256.lt (; 75 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  local.get $0
+  i64.load offset=16
+  local.set $2
+  local.get $1
+  i64.load offset=16
+  local.set $3
+  local.get $0
+  i64.load offset=8
+  local.set $4
+  local.get $1
+  i64.load offset=8
+  local.set $5
+  local.get $0
+  i64.load offset=24
+  local.tee $6
+  local.get $1
+  i64.load offset=24
+  local.tee $7
+  i64.eq
+  if (result i32)
+   local.get $2
+   local.get $3
+   i64.eq
+   if (result i32)
+    local.get $4
+    local.get $5
+    i64.eq
+    if (result i32)
+     local.get $0
+     i64.load
+     local.get $1
+     i64.load
+     i64.lt_u
+    else     
+     local.get $4
+     local.get $5
+     i64.lt_u
+    end
+   else    
+    local.get $2
+    local.get $3
+    i64.lt_u
+   end
+  else   
+   local.get $6
+   local.get $7
+   i64.lt_u
+  end
+ )
+ (func $assembly/integer/u256/u256.gt (; 76 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  local.get $1
+  i64.load offset=16
+  local.set $2
+  local.get $0
+  i64.load offset=16
+  local.set $3
+  local.get $1
+  i64.load offset=8
+  local.set $4
+  local.get $0
+  i64.load offset=8
+  local.set $5
+  local.get $1
+  i64.load offset=24
+  local.tee $6
+  local.get $0
+  i64.load offset=24
+  local.tee $7
+  i64.eq
+  if (result i32)
+   local.get $2
+   local.get $3
+   i64.eq
+   if (result i32)
+    local.get $4
+    local.get $5
+    i64.eq
+    if (result i32)
+     local.get $1
+     i64.load
+     local.get $0
+     i64.load
+     i64.lt_u
+    else     
+     local.get $4
+     local.get $5
+     i64.lt_u
+    end
+   else    
+    local.get $2
+    local.get $3
+    i64.lt_u
+   end
+  else   
+   local.get $6
+   local.get $7
+   i64.lt_u
+  end
+  i32.const 0
+  i32.ne
+ )
+ (func $assembly/integer/u256/u256.le (; 77 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  local.get $1
+  i64.load offset=16
+  local.set $2
+  local.get $0
+  i64.load offset=16
+  local.set $3
+  local.get $1
+  i64.load offset=8
+  local.set $4
+  local.get $0
+  i64.load offset=8
+  local.set $5
+  local.get $1
+  i64.load offset=24
+  local.tee $6
+  local.get $0
+  i64.load offset=24
+  local.tee $7
+  i64.eq
+  if (result i32)
+   local.get $2
+   local.get $3
+   i64.eq
+   if (result i32)
+    local.get $4
+    local.get $5
+    i64.eq
+    if (result i32)
+     local.get $1
+     i64.load
+     local.get $0
+     i64.load
+     i64.lt_u
+    else     
+     local.get $4
+     local.get $5
+     i64.lt_u
+    end
+   else    
+    local.get $2
+    local.get $3
+    i64.lt_u
+   end
+  else   
+   local.get $6
+   local.get $7
+   i64.lt_u
+  end
+  i32.eqz
+ )
+ (func $assembly/integer/u256/u256.ge (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  local.get $0
+  i64.load offset=16
+  local.set $2
+  local.get $1
+  i64.load offset=16
+  local.set $3
+  local.get $0
+  i64.load offset=8
+  local.set $4
+  local.get $1
+  i64.load offset=8
+  local.set $5
+  local.get $0
+  i64.load offset=24
+  local.tee $6
+  local.get $1
+  i64.load offset=24
+  local.tee $7
+  i64.eq
+  if (result i32)
+   local.get $2
+   local.get $3
+   i64.eq
+   if (result i32)
+    local.get $4
+    local.get $5
+    i64.eq
+    if (result i32)
+     local.get $0
+     i64.load
+     local.get $1
+     i64.load
+     i64.lt_u
+    else     
+     local.get $4
+     local.get $5
+     i64.lt_u
+    end
+   else    
+    local.get $2
+    local.get $3
+    i64.lt_u
+   end
+  else   
+   local.get $6
+   local.get $7
+   i64.lt_u
+  end
+  i32.eqz
+ )
+ (func $assembly/integer/u256/u256.popcnt (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   local.get $0
   i64.load
@@ -2068,7 +2376,7 @@
   end
   i32.wrap_i64
  )
- (func $assembly/integer/u256/u256.clz (; 74 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.clz (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   i64.const 0
@@ -2115,7 +2423,7 @@
    end
   end
  )
- (func $assembly/integer/u256/u256.ctz (; 75 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.ctz (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   i64.const 0
@@ -2162,7 +2470,7 @@
    end
   end
  )
- (func $assembly/integer/u256/u256#set (; 76 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#set (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.load
@@ -2181,7 +2489,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU128 (; 77 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setU128 (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.load
@@ -2198,7 +2506,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setI64 (; 78 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $assembly/integer/u256/u256#setI64 (; 84 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   i64.store
@@ -2216,7 +2524,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU64 (; 79 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $assembly/integer/u256/u256#setU64 (; 85 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   i64.store
@@ -2231,7 +2539,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setI32 (; 80 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setI32 (; 86 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -2252,7 +2560,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU32 (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setU32 (; 87 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.extend_i32_u
@@ -2268,7 +2576,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#isZero (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#isZero (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   local.get $0
@@ -2282,7 +2590,7 @@
   i64.or
   i64.eqz
  )
- (func $assembly/integer/u256/u256#toI128 (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toI128 (; 89 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   drop
@@ -2298,7 +2606,7 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256#toI64 (; 84 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $assembly/integer/u256/u256#toI64 (; 90 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load
   i64.const 9223372036854775807
@@ -2309,7 +2617,7 @@
   i64.and
   i64.or
  )
- (func $assembly/integer/u256/u256#toI32 (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toI32 (; 91 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   i64.const 9223372036854775807
@@ -2321,7 +2629,7 @@
   i64.or
   i32.wrap_i64
  )
- (func $assembly/integer/u256/u256#toBool (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBool (; 92 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   local.get $0
@@ -2336,274 +2644,7 @@
   i64.const 0
   i64.ne
  )
- (func $assembly/integer/u256/u256#toBytesLE (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i64)
-  (local $2 i64)
-  (local $3 i64)
-  (local $4 i64)
-  local.get $0
-  i64.load offset=16
-  local.set $1
-  local.get $0
-  i64.load
-  local.set $2
-  local.get $0
-  i64.load offset=24
-  local.set $3
-  local.get $0
-  i64.load offset=8
-  local.set $4
-  i32.const 32
-  call $~lib/array/Array<u8>#constructor
-  local.tee $0
-  i32.load
-  local.get $2
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.add
-  local.get $2
-  i64.const 8
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 2
-  i32.add
-  local.get $2
-  i64.const 16
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 3
-  i32.add
-  local.get $2
-  i64.const 24
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 4
-  i32.add
-  local.get $2
-  i64.const 32
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 5
-  i32.add
-  local.get $2
-  i64.const 40
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 6
-  i32.add
-  local.get $2
-  i64.const 48
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 7
-  i32.add
-  local.get $2
-  i64.const 56
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 8
-  i32.add
-  local.get $4
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 9
-  i32.add
-  local.get $4
-  i64.const 8
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 10
-  i32.add
-  local.get $4
-  i64.const 16
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 11
-  i32.add
-  local.get $4
-  i64.const 24
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 12
-  i32.add
-  local.get $4
-  i64.const 32
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 13
-  i32.add
-  local.get $4
-  i64.const 40
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 14
-  i32.add
-  local.get $4
-  i64.const 48
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 15
-  i32.add
-  local.get $4
-  i64.const 56
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 16
-  i32.add
-  local.get $1
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 17
-  i32.add
-  local.get $1
-  i64.const 8
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 18
-  i32.add
-  local.get $1
-  i64.const 16
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 19
-  i32.add
-  local.get $1
-  i64.const 24
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 20
-  i32.add
-  local.get $1
-  i64.const 32
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 21
-  i32.add
-  local.get $1
-  i64.const 40
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 22
-  i32.add
-  local.get $1
-  i64.const 48
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 23
-  i32.add
-  local.get $1
-  i64.const 56
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 24
-  i32.add
-  local.get $3
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 25
-  i32.add
-  local.get $3
-  i64.const 8
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 26
-  i32.add
-  local.get $3
-  i64.const 16
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 27
-  i32.add
-  local.get $3
-  i64.const 24
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 28
-  i32.add
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 29
-  i32.add
-  local.get $3
-  i64.const 40
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 30
-  i32.add
-  local.get $3
-  i64.const 48
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
-  i32.load
-  i32.const 31
-  i32.add
-  local.get $3
-  i64.const 56
-  i64.shr_u
-  i64.store8 offset=8
-  local.get $0
- )
- (func $assembly/integer/u256/u256#toBytesBE (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytesBE (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2870,7 +2911,274 @@
   i64.store8 offset=8
   local.get $0
  )
- (func $assembly/integer/u256/u256#toString (; 89 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytesLE (; 94 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i64)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  local.get $0
+  i64.load offset=16
+  local.set $1
+  local.get $0
+  i64.load
+  local.set $2
+  local.get $0
+  i64.load offset=24
+  local.set $3
+  local.get $0
+  i64.load offset=8
+  local.set $4
+  i32.const 32
+  call $~lib/array/Array<u8>#constructor
+  local.tee $0
+  i32.load
+  local.get $2
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.add
+  local.get $2
+  i64.const 8
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 2
+  i32.add
+  local.get $2
+  i64.const 16
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 3
+  i32.add
+  local.get $2
+  i64.const 24
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 4
+  i32.add
+  local.get $2
+  i64.const 32
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 5
+  i32.add
+  local.get $2
+  i64.const 40
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 6
+  i32.add
+  local.get $2
+  i64.const 48
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 7
+  i32.add
+  local.get $2
+  i64.const 56
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 8
+  i32.add
+  local.get $4
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 9
+  i32.add
+  local.get $4
+  i64.const 8
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 10
+  i32.add
+  local.get $4
+  i64.const 16
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 11
+  i32.add
+  local.get $4
+  i64.const 24
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 12
+  i32.add
+  local.get $4
+  i64.const 32
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 13
+  i32.add
+  local.get $4
+  i64.const 40
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 14
+  i32.add
+  local.get $4
+  i64.const 48
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 15
+  i32.add
+  local.get $4
+  i64.const 56
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 16
+  i32.add
+  local.get $1
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 17
+  i32.add
+  local.get $1
+  i64.const 8
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 18
+  i32.add
+  local.get $1
+  i64.const 16
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 19
+  i32.add
+  local.get $1
+  i64.const 24
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 20
+  i32.add
+  local.get $1
+  i64.const 32
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 21
+  i32.add
+  local.get $1
+  i64.const 40
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 22
+  i32.add
+  local.get $1
+  i64.const 48
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 23
+  i32.add
+  local.get $1
+  i64.const 56
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 24
+  i32.add
+  local.get $3
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 25
+  i32.add
+  local.get $3
+  i64.const 8
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 26
+  i32.add
+  local.get $3
+  i64.const 16
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 27
+  i32.add
+  local.get $3
+  i64.const 24
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 28
+  i32.add
+  local.get $3
+  i64.const 32
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 29
+  i32.add
+  local.get $3
+  i64.const 40
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 30
+  i32.add
+  local.get $3
+  i64.const 48
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+  i32.load
+  i32.const 31
+  i32.add
+  local.get $3
+  i64.const 56
+  i64.shr_u
+  i64.store8 offset=8
+  local.get $0
+ )
+ (func $assembly/integer/u256/u256#toString (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 10
@@ -2891,7 +3199,7 @@
   if
    i32.const 672
    i32.const 936
-   i32.const 409
+   i32.const 468
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -2926,24 +3234,24 @@
   drop
   unreachable
  )
- (func $null (; 90 ;) (type $FUNCSIG$v)
+ (func $null (; 96 ;) (type $FUNCSIG$v)
   nop
  )
- (func $u128#set:lo (; 91 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u128#set:lo (; 97 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store
  )
- (func $u128#get:hi (; 92 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u128#get:hi (; 98 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=8
  )
- (func $u128#set:hi (; 93 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u128#set:hi (; 99 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=8
  )
- (func $assembly/integer/u128/u128#constructor|trampoline (; 94 ;) (type $FUNCSIG$iijj) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $assembly/integer/u128/u128#constructor|trampoline (; 100 ;) (type $FUNCSIG$iijj) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -2972,11 +3280,11 @@
   i64.store offset=8
   local.get $0
  )
- (func $~lib/setargc (; 95 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/setargc (; 101 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $assembly/integer/u128/u128#toBytes|trampoline (; 96 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128#toBytes|trampoline (; 102 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2997,7 +3305,7 @@
    call $assembly/integer/u128/u128#toBytesLE
   end
  )
- (func $assembly/integer/u128/u128#toString|trampoline (; 97 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128#toString|trampoline (; 103 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3013,7 +3321,7 @@
   local.get $1
   call $assembly/integer/u128/u128#toString
  )
- (func $assembly/integer/u128/u128.fromString|trampoline (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128.fromString|trampoline (; 104 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3031,7 +3339,7 @@
   local.get $1
   call $assembly/utils/atou128
  )
- (func $assembly/integer/u128/u128.fromBytes|trampoline (; 99 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128.fromBytes|trampoline (; 105 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3054,25 +3362,25 @@
    call $assembly/integer/u128/u128.fromBytesLE
   end
  )
- (func $u256#get:hi1 (; 100 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u256#get:hi1 (; 106 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=16
  )
- (func $u256#set:hi1 (; 101 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u256#set:hi1 (; 107 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=16
  )
- (func $u256#get:hi2 (; 102 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u256#get:hi2 (; 108 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=24
  )
- (func $u256#set:hi2 (; 103 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u256#set:hi2 (; 109 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=24
  )
- (func $assembly/integer/u256/u256#constructor|trampoline (; 104 ;) (type $FUNCSIG$iijjjj) (param $0 i32) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (result i32)
+ (func $assembly/integer/u256/u256#constructor|trampoline (; 110 ;) (type $FUNCSIG$iijjjj) (param $0 i32) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (result i32)
   block $4of4
    block $3of4
     block $2of4
@@ -3115,7 +3423,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#toBytes|trampoline (; 105 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytes|trampoline (; 111 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3124,19 +3432,19 @@
     end
     unreachable
    end
-   i32.const 1
+   i32.const 0
    local.set $1
   end
   local.get $1
   if (result i32)
    local.get $0
-   call $assembly/integer/u256/u256#toBytesLE
+   call $assembly/integer/u256/u256#toBytesBE
   else   
    local.get $0
-   call $assembly/integer/u256/u256#toBytesBE
+   call $assembly/integer/u256/u256#toBytesLE
   end
  )
- (func $assembly/integer/u256/u256#toString|trampoline (; 106 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#toString|trampoline (; 112 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3152,7 +3460,7 @@
   local.get $1
   call $assembly/integer/u256/u256#toString
  )
- (func $assembly/integer/u256/u256.fromBytes|trampoline (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256.fromBytes|trampoline (; 113 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/build/release/bignum.wat
+++ b/build/release/bignum.wat
@@ -15,9 +15,9 @@
  (type $FUNCSIG$ji (func (param i32) (result i64)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
  (type $FUNCSIG$fi (func (param i32) (result f32)))
+ (type $FUNCSIG$vij (func (param i32 i64)))
  (type $FUNCSIG$iiiiiiiii (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$vij (func (param i32 i64)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vjj (func (param i64 i64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -39,6 +39,7 @@
  (data (i32.const 832) "\04\00\00\00n\00u\00l\00l")
  (data (i32.const 848) "\1b\00\00\00~\00l\00i\00b\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 912) "\t\00\00\00u\00n\00d\00e\00f\00i\00n\00e\00d")
+ (data (i32.const 936) "\18\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00t\00e\00g\00e\00r\00/\00u\002\005\006\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $assembly/globals/__divmod_quot_lo (mut i64) (i64.const 0))
@@ -167,6 +168,7 @@
  (export "u256#toBytesLE" (func $assembly/integer/u256/u256#toBytesLE))
  (export "u256#toBytesBE" (func $assembly/integer/u256/u256#toBytesBE))
  (export "u256#clone" (func $assembly/integer/u256/u256.fromU256))
+ (export "u256#toString" (func $assembly/integer/u256/u256#toString|trampoline))
  (export "u256.get:Zero" (func $assembly/integer/u128/u128.Zero.get:Zero))
  (export "u256.get:One" (func $assembly/integer/u128/u128.Zero.get:Zero))
  (export "u256.get:Min" (func $assembly/integer/u128/u128.Zero.get:Zero))
@@ -178,7 +180,9 @@
  (export "u256.fromU32" (func $assembly/integer/u128/u128.fromI32))
  (export "u256.fromI32" (func $assembly/integer/u128/u128.fromI32))
  (export "u256.fromBits" (func $assembly/integer/u256/u256.fromBits))
- (export "u256.fromBytes" (func $assembly/integer/u128/u128.fromI32))
+ (export "u256.fromBytes" (func $assembly/integer/u256/u256.fromBytes|trampoline))
+ (export "u256.fromBytesLE" (func $assembly/integer/u256/u256.fromBytesLE))
+ (export "u256.fromBytesBE" (func $assembly/integer/u256/u256.fromBytesBE))
  (export "u256.fromF64" (func $assembly/integer/u128/u128.fromF64))
  (export "u256.fromF32" (func $assembly/integer/u128/u128.fromF32))
  (export "u256.isEmpty" (func $assembly/integer/u256/u256.isEmpty))
@@ -186,6 +190,8 @@
  (export "u256.or" (func $assembly/integer/u256/u256.or))
  (export "u256.xor" (func $assembly/integer/u256/u256.xor))
  (export "u256.and" (func $assembly/integer/u256/u256.and))
+ (export "u256.shr" (func $assembly/integer/u256/u256.shr))
+ (export "u256.shr_u" (func $assembly/integer/u256/u256.shr))
  (export "u256.popcnt" (func $assembly/integer/u256/u256.popcnt))
  (export "u256.clz" (func $assembly/integer/u256/u256.clz))
  (export "u256.ctz" (func $assembly/integer/u256/u256.ctz))
@@ -302,7 +308,7 @@
   if
    i32.const 0
    i32.const 312
-   i32.const 159
+   i32.const 197
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -1727,7 +1733,101 @@
  (func $assembly/integer/u256/u256.fromBits (; 64 ;) (type $FUNCSIG$iiiiiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (param $7 i32) (result i32)
   unreachable
  )
- (func $assembly/integer/u256/u256.isEmpty (; 65 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.fromBytesBE (; 65 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  if (result i32)
+   local.get $0
+   i32.load offset=4
+   i32.const 31
+   i32.and
+   i32.eqz
+  else   
+   local.get $1
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 936
+   i32.const 78
+   i32.const 4
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i32.load
+  local.tee $0
+  i32.const 24
+  i32.add
+  i64.load offset=8
+  call $~lib/polyfills/bswap<u64>
+  drop
+  local.get $0
+  i32.const 16
+  i32.add
+  i64.load offset=8
+  call $~lib/polyfills/bswap<u64>
+  drop
+  local.get $0
+  i32.const 8
+  i32.add
+  i64.load offset=8
+  call $~lib/polyfills/bswap<u64>
+  drop
+  local.get $0
+  i64.load offset=8
+  call $~lib/polyfills/bswap<u64>
+  drop
+  unreachable
+ )
+ (func $assembly/integer/u256/u256.fromBytesLE (; 66 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  if (result i32)
+   local.get $0
+   i32.load offset=4
+   i32.const 31
+   i32.and
+   i32.eqz
+  else   
+   local.get $1
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 936
+   i32.const 67
+   i32.const 4
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i32.load
+  local.tee $0
+  i64.load offset=8
+  drop
+  local.get $0
+  i32.const 8
+  i32.add
+  i64.load offset=8
+  drop
+  local.get $0
+  i32.const 16
+  i32.add
+  i64.load offset=8
+  drop
+  local.get $0
+  i32.const 24
+  i32.add
+  i64.load offset=8
+  drop
+  unreachable
+ )
+ (func $assembly/integer/u256/u256.isEmpty (; 67 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.eqz
@@ -1751,7 +1851,7 @@
   end
   local.get $1
  )
- (func $assembly/integer/u256/u256.add (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256.add (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   i64.load
   drop
@@ -1760,7 +1860,7 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256.or (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256.or (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i64.load
   local.get $1
@@ -1787,7 +1887,7 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256.xor (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256.xor (; 70 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i64.load
   local.get $1
@@ -1814,7 +1914,7 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256.and (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256.and (; 71 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i64.load
   local.get $1
@@ -1841,7 +1941,89 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256.popcnt (; 70 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.shr (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i64)
+  local.get $1
+  i32.const 255
+  i32.and
+  i64.extend_i32_s
+  local.tee $2
+  i64.const 64
+  i64.le_u
+  if
+   local.get $0
+   i64.load
+   local.get $2
+   i64.shr_u
+   local.get $0
+   i64.load offset=8
+   local.get $2
+   i64.shr_u
+   local.get $0
+   i64.load offset=16
+   local.get $2
+   i64.shr_u
+   local.get $0
+   i64.load offset=24
+   local.get $2
+   i64.shr_u
+   i64.const 64
+   local.get $2
+   i64.sub
+   local.tee $2
+   i64.shl
+   i64.or
+   local.get $2
+   i64.shl
+   i64.or
+   local.get $2
+   i64.shl
+   i64.or
+   drop
+  else   
+   local.get $2
+   i64.const 64
+   i64.gt_u
+   local.tee $1
+   if (result i32)
+    local.get $2
+    i64.const 128
+    i64.le_u
+   else    
+    local.get $1
+   end
+   if
+    local.get $0
+    i64.load offset=8
+    drop
+    local.get $0
+    i64.load offset=16
+    drop
+   else    
+    local.get $2
+    i64.const 128
+    i64.gt_u
+    local.tee $1
+    if (result i32)
+     local.get $2
+     i64.const 192
+     i64.le_u
+    else     
+     local.get $1
+    end
+    if
+     local.get $0
+     i64.load offset=16
+     drop
+    end
+   end
+   local.get $0
+   i64.load offset=24
+   drop
+  end
+  unreachable
+ )
+ (func $assembly/integer/u256/u256.popcnt (; 73 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   local.get $0
   i64.load
@@ -1886,7 +2068,7 @@
   end
   i32.wrap_i64
  )
- (func $assembly/integer/u256/u256.clz (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.clz (; 74 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   i64.const 0
@@ -1933,7 +2115,7 @@
    end
   end
  )
- (func $assembly/integer/u256/u256.ctz (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256.ctz (; 75 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   i64.const 0
@@ -1980,7 +2162,7 @@
    end
   end
  )
- (func $assembly/integer/u256/u256#set (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#set (; 76 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.load
@@ -1999,7 +2181,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU128 (; 74 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setU128 (; 77 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.load
@@ -2016,7 +2198,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setI64 (; 75 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $assembly/integer/u256/u256#setI64 (; 78 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   i64.store
@@ -2034,7 +2216,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU64 (; 76 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $assembly/integer/u256/u256#setU64 (; 79 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   i64.store
@@ -2049,7 +2231,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setI32 (; 77 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setI32 (; 80 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -2070,7 +2252,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#setU32 (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#setU32 (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i64.extend_i32_u
@@ -2086,7 +2268,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#isZero (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#isZero (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   local.get $0
@@ -2100,7 +2282,7 @@
   i64.or
   i64.eqz
  )
- (func $assembly/integer/u256/u256#toI128 (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toI128 (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   drop
@@ -2116,7 +2298,7 @@
   drop
   unreachable
  )
- (func $assembly/integer/u256/u256#toI64 (; 81 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $assembly/integer/u256/u256#toI64 (; 84 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load
   i64.const 9223372036854775807
@@ -2127,7 +2309,7 @@
   i64.and
   i64.or
  )
- (func $assembly/integer/u256/u256#toI32 (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toI32 (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load
   i64.const 9223372036854775807
@@ -2139,7 +2321,7 @@
   i64.or
   i32.wrap_i64
  )
- (func $assembly/integer/u256/u256#toBool (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBool (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i64.load offset=24
   local.get $0
@@ -2154,7 +2336,7 @@
   i64.const 0
   i64.ne
  )
- (func $assembly/integer/u256/u256#toBytesLE (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytesLE (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2421,7 +2603,7 @@
   i64.store8 offset=8
   local.get $0
  )
- (func $assembly/integer/u256/u256#toBytesBE (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytesBE (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2688,24 +2870,80 @@
   i64.store8 offset=8
   local.get $0
  )
- (func $null (; 86 ;) (type $FUNCSIG$v)
+ (func $assembly/integer/u256/u256#toString (; 89 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 10
+  local.get $1
+  select
+  local.tee $2
+  i32.const 10
+  i32.eq
+  local.tee $1
+  if (result i32)
+   local.get $1
+  else   
+   local.get $2
+   i32.const 16
+   i32.eq
+  end
+  i32.eqz
+  if
+   i32.const 672
+   i32.const 936
+   i32.const 409
+   i32.const 4
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i64.load offset=24
+  local.get $0
+  i64.load offset=16
+  local.get $0
+  i64.load
+  local.get $0
+  i64.load offset=8
+  i64.or
+  i64.or
+  i64.or
+  i64.eqz
+  if
+   i32.const 760
+   return
+  end
+  local.get $0
+  i64.load
+  drop
+  local.get $0
+  i64.load offset=8
+  drop
+  local.get $0
+  i64.load offset=16
+  drop
+  local.get $0
+  i64.load offset=24
+  drop
+  unreachable
+ )
+ (func $null (; 90 ;) (type $FUNCSIG$v)
   nop
  )
- (func $u128#set:lo (; 87 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u128#set:lo (; 91 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store
  )
- (func $u128#get:hi (; 88 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u128#get:hi (; 92 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=8
  )
- (func $u128#set:hi (; 89 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u128#set:hi (; 93 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=8
  )
- (func $assembly/integer/u128/u128#constructor|trampoline (; 90 ;) (type $FUNCSIG$iijj) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $assembly/integer/u128/u128#constructor|trampoline (; 94 ;) (type $FUNCSIG$iijj) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -2734,11 +2972,11 @@
   i64.store offset=8
   local.get $0
  )
- (func $~lib/setargc (; 91 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/setargc (; 95 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $assembly/integer/u128/u128#toBytes|trampoline (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128#toBytes|trampoline (; 96 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2759,7 +2997,7 @@
    call $assembly/integer/u128/u128#toBytesLE
   end
  )
- (func $assembly/integer/u128/u128#toString|trampoline (; 93 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128#toString|trampoline (; 97 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2775,7 +3013,7 @@
   local.get $1
   call $assembly/integer/u128/u128#toString
  )
- (func $assembly/integer/u128/u128.fromString|trampoline (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128.fromString|trampoline (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2793,7 +3031,7 @@
   local.get $1
   call $assembly/utils/atou128
  )
- (func $assembly/integer/u128/u128.fromBytes|trampoline (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u128/u128.fromBytes|trampoline (; 99 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2816,25 +3054,25 @@
    call $assembly/integer/u128/u128.fromBytesLE
   end
  )
- (func $u256#get:hi1 (; 96 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u256#get:hi1 (; 100 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=16
  )
- (func $u256#set:hi1 (; 97 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u256#set:hi1 (; 101 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=16
  )
- (func $u256#get:hi2 (; 98 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $u256#get:hi2 (; 102 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load offset=24
  )
- (func $u256#set:hi2 (; 99 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $u256#set:hi2 (; 103 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store offset=24
  )
- (func $assembly/integer/u256/u256#constructor|trampoline (; 100 ;) (type $FUNCSIG$iijjjj) (param $0 i32) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (result i32)
+ (func $assembly/integer/u256/u256#constructor|trampoline (; 104 ;) (type $FUNCSIG$iijjjj) (param $0 i32) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (result i32)
   block $4of4
    block $3of4
     block $2of4
@@ -2877,7 +3115,7 @@
   i64.store offset=24
   local.get $0
  )
- (func $assembly/integer/u256/u256#toBytes|trampoline (; 101 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $assembly/integer/u256/u256#toBytes|trampoline (; 105 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2896,6 +3134,45 @@
   else   
    local.get $0
    call $assembly/integer/u256/u256#toBytesBE
+  end
+ )
+ (func $assembly/integer/u256/u256#toString|trampoline (; 106 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  block $1of1
+   block $0of1
+    block $outOfRange
+     global.get $~lib/argc
+     br_table $0of1 $1of1 $outOfRange
+    end
+    unreachable
+   end
+   i32.const 0
+   local.set $1
+  end
+  local.get $0
+  local.get $1
+  call $assembly/integer/u256/u256#toString
+ )
+ (func $assembly/integer/u256/u256.fromBytes|trampoline (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  block $1of1
+   block $0of1
+    block $outOfRange
+     global.get $~lib/argc
+     i32.const 1
+     i32.sub
+     br_table $0of1 $1of1 $outOfRange
+    end
+    unreachable
+   end
+   i32.const 0
+   local.set $1
+  end
+  local.get $1
+  if (result i32)
+   local.get $0
+   call $assembly/integer/u256/u256.fromBytesBE
+  else   
+   local.get $0
+   call $assembly/integer/u256/u256.fromBytesLE
   end
  )
 )

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "build:release": "npx asc assembly/index.ts -b build/release/bignum.wasm -t build/release/bignum.wat -O3 --sourceMap --validate",
     "build:wasm": "yarn build:debug && yarn build:release",
     "build:test:u128": "npx asc tests/assembly/u128.spec.as.ts -b tests/build/u128.wasm -t tests/build/u128.wat --validate --sourceMap --importMemory --debug",
+    "build:test:u256": "npx asc tests/assembly/u256.spec.as.ts -b tests/build/u256.wasm -t tests/build/u256.wat --validate --sourceMap --importMemory --debug",
     "build:test:safe_u128": "npx asc tests/assembly/safe_u128.spec.as.ts -b tests/build/safe_u128.wasm -t tests/build/safe_u128.wat --validate --sourceMap --importMemory --debug",
-    "build:test": "yarn build:test:u128 && yarn build:test:safe_u128",
+    "build:test": "yarn build:test:u128 && yarn build:test:u256 && yarn build:test:safe_u128",
     "build": "yarn build:wasm",
     "test": "yarn build:test && ava -v",
     "test:ci": "yarn build:test && ava --fail-fast"

--- a/tests/assembly/u256.spec.as.ts
+++ b/tests/assembly/u256.spec.as.ts
@@ -6,88 +6,88 @@ declare function logU256Packed(msg: string | null, lo1: f64, lo2: f64, hi1: f64,
 declare function logF64(val: f64): void;
 
 function logU256(value: u256, msg: string | null = null): void {
-    assert(value);
-    logU256Packed(msg,
-        reinterpret<f64>(value.lo1),
-        reinterpret<f64>(value.lo2),
-        reinterpret<f64>(value.hi1),
-        reinterpret<f64>(value.hi2),
-    );
+  assert(value);
+  logU256Packed(msg,
+    reinterpret<f64>(value.lo1),
+    reinterpret<f64>(value.lo2),
+    reinterpret<f64>(value.hi1),
+    reinterpret<f64>(value.hi2),
+  );
 }
 
 export class StringConversionTests {
-    static shouldConvertToDecimalString1(): bool {
-        var a = new u256(10248516654965971928, 5, 0, 0);
-        return '102482237023513730008' == a.toString();
-    }
+  static shouldConvertToDecimalString1(): bool {
+    var a = new u256(10248516654965971928, 5, 0, 0);
+    return '102482237023513730008' == a.toString();
+  }
 
-    static shouldConvertToDecimalString2(): bool {
-        var a = new u256(1, 1, 1, 1);
-        return '6277101735386680764176071790128604879584176795969512275969' == a.toString();
-    }
+  static shouldConvertToDecimalString2(): bool {
+    var a = new u256(1, 1, 1, 1);
+    return '6277101735386680764176071790128604879584176795969512275969' == a.toString();
+  }
 
-    static shouldConvertToDecimalString3(): bool {
-        var a = u256.Max;
-        return '115792089237316195423570985008687907853269984665640564039457584007913129639935' == a.toString();
-    }
+  static shouldConvertToDecimalString3(): bool {
+    var a = u256.Max;
+    return '115792089237316195423570985008687907853269984665640564039457584007913129639935' == a.toString();
+  }
 
-    static shouldConvertToDecimalString4(): bool {
-        var a = u256.Zero;
-        return '0' == a.toString();
-    }
+  static shouldConvertToDecimalString4(): bool {
+    var a = u256.Zero;
+    return '0' == a.toString();
+  }
 }
 
 export class BufferConversionTests {
-    static shouldConvertFromBytesLittleEndian(): bool {
-        var arr: u8[] = [
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
-        ];
+  static shouldConvertFromBytesLittleEndian(): bool {
+    var arr: u8[] = [
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
+    ];
 
-        return u256.fromBytes(arr) == new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
-    }
+    return u256.fromBytes(arr) == new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
+  }
 
-    static shouldConvertFromBytesBigEndian(): bool {
-        var arr: u8[] = [
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
-        ];
+  static shouldConvertFromBytesBigEndian(): bool {
+    var arr: u8[] = [
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
+    ];
 
-        return u256.fromBytes(arr, true) == new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
-    }
+    return u256.fromBytes(arr, true) == new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
+  }
 
-    static shouldConvertToBytesLitteEndian(): bool {
-        // var a: u8[] = (new u128(0x8877665544332211, 0x12ffeeddccbbaa99)).toBytes();
-        var u = new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
-        var a = u.toBytes();
-        return (
-            a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
-            a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
-            a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
-            a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
-            a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
-            a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
-            a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
-            a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
-        );
-    }
+  static shouldConvertToBytesLitteEndian(): bool {
+    // var a: u8[] = (new u128(0x8877665544332211, 0x12ffeeddccbbaa99)).toBytes();
+    var u = new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
+    var a = u.toBytes();
+    return (
+      a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
+      a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
+      a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
+      a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
+      a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
+      a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
+      a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
+      a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
+    );
+  }
 
-    static shouldConvertToBytesBigEndian(): bool {
-        var u = new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
-        var a = u.toBytes(true);
-        return (
-            a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
-            a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
-            a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
-            a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
-            a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
-            a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
-            a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
-            a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
-        );
-    }
+  static shouldConvertToBytesBigEndian(): bool {
+    var u = new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
+    var a = u.toBytes(true);
+    return (
+      a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
+      a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
+      a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
+      a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
+      a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
+      a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
+      a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
+      a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
+    );
+  }
 }

--- a/tests/assembly/u256.spec.as.ts
+++ b/tests/assembly/u256.spec.as.ts
@@ -1,0 +1,93 @@
+import 'allocator/arena';
+import { u256 } from '../../assembly/integer/u256';
+
+declare function logStr(str: string | null): void;
+declare function logU256Packed(msg: string | null, lo1: f64, lo2: f64, hi1: f64, hi2: f64): void;
+declare function logF64(val: f64): void;
+
+function logU256(value: u256, msg: string | null = null): void {
+    assert(value);
+    logU256Packed(msg,
+        reinterpret<f64>(value.lo1),
+        reinterpret<f64>(value.lo2),
+        reinterpret<f64>(value.hi1),
+        reinterpret<f64>(value.hi2),
+    );
+}
+
+export class StringConversionTests {
+    static shouldConvertToDecimalString1(): bool {
+        var a = new u256(10248516654965971928, 5, 0, 0);
+        return '102482237023513730008' == a.toString();
+    }
+
+    static shouldConvertToDecimalString2(): bool {
+        var a = new u256(1, 1, 1, 1);
+        return '6277101735386680764176071790128604879584176795969512275969' == a.toString();
+    }
+
+    static shouldConvertToDecimalString3(): bool {
+        var a = u256.Max;
+        return '115792089237316195423570985008687907853269984665640564039457584007913129639935' == a.toString();
+    }
+
+    static shouldConvertToDecimalString4(): bool {
+        var a = u256.Zero;
+        return '0' == a.toString();
+    }
+}
+
+export class BufferConversionTests {
+    static shouldConvertFromBytesLittleEndian(): bool {
+        var arr: u8[] = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
+        ];
+
+        return u256.fromBytes(arr) == new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
+    }
+
+    static shouldConvertFromBytesBigEndian(): bool {
+        var arr: u8[] = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12,
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x12
+        ];
+
+        return u256.fromBytes(arr, true) == new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
+    }
+
+    static shouldConvertToBytesLitteEndian(): bool {
+        // var a: u8[] = (new u128(0x8877665544332211, 0x12ffeeddccbbaa99)).toBytes();
+        var u = new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
+        var a = u.toBytes();
+        return (
+            a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
+            a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
+            a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
+            a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
+            a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
+            a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
+            a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
+            a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
+        );
+    }
+
+    static shouldConvertToBytesBigEndian(): bool {
+        var u = new u256(0x99aabbccddeeff12, 0x1122334455667788, 0x99aabbccddeeff12, 0x1122334455667788);
+        var a = u.toBytes(true);
+        return (
+            a[0]  == 0x11 && a[1]  == 0x22 && a[2]  == 0x33 && a[3]  == 0x44 &&
+            a[4]  == 0x55 && a[5]  == 0x66 && a[6]  == 0x77 && a[7]  == 0x88 &&
+            a[8]  == 0x99 && a[9]  == 0xAA && a[10] == 0xBB && a[11] == 0xCC &&
+            a[12] == 0xDD && a[13] == 0xEE && a[14] == 0xFF && a[15] == 0x12 &&
+            a[16] == 0x11 && a[17] == 0x22 && a[18] == 0x33 && a[19] == 0x44 &&
+            a[20] == 0x55 && a[21] == 0x66 && a[22] == 0x77 && a[23] == 0x88 &&
+            a[24] == 0x99 && a[25] == 0xAA && a[26] == 0xBB && a[27] == 0xCC &&
+            a[28] == 0xDD && a[29] == 0xEE && a[30] == 0xFF && a[31] == 0x12
+        );
+    }
+}

--- a/tests/assembly/u256.spec.as.ts
+++ b/tests/assembly/u256.spec.as.ts
@@ -61,7 +61,6 @@ export class BufferConversionTests {
   }
 
   static shouldConvertToBytesLitteEndian(): bool {
-    // var a: u8[] = (new u128(0x8877665544332211, 0x12ffeeddccbbaa99)).toBytes();
     var u = new u256(0x8877665544332211, 0x12ffeeddccbbaa99, 0x8877665544332211, 0x12ffeeddccbbaa99);
     var a = u.toBytes();
     return (

--- a/tests/integer/u256.spec.ts
+++ b/tests/integer/u256.spec.ts
@@ -2,18 +2,18 @@ import test from 'ava';
 import { setup, decamelize, isThrowable } from '../utils/helpers';
 
 (async () => {
-    const instance = await setup('u256');
+  const instance = await setup('u256');
 
-    for (const tests in instance) {
-        const testsInstance = instance[tests];
-        if (isThrowable(tests)) {
-            for (const testName in testsInstance) {
-                test(decamelize(testName), t => { t.throws(() => testsInstance[testName]()) });
-            }
-        } else {
-            for (const testName in testsInstance) {
-                test(decamelize(testName), t => { t.truthy(testsInstance[testName]()) });
-            }
-        }
+  for (const tests in instance) {
+    const testsInstance = instance[tests];
+    if (isThrowable(tests)) {
+      for (const testName in testsInstance) {
+        test(decamelize(testName), t => { t.throws(() => testsInstance[testName]()) });
+      }
+    } else {
+      for (const testName in testsInstance) {
+        test(decamelize(testName), t => { t.truthy(testsInstance[testName]()) });
+      }
     }
+  }
 })();

--- a/tests/integer/u256.spec.ts
+++ b/tests/integer/u256.spec.ts
@@ -1,0 +1,19 @@
+import test from 'ava';
+import { setup, decamelize, isThrowable } from '../utils/helpers';
+
+(async () => {
+    const instance = await setup('u256');
+
+    for (const tests in instance) {
+        const testsInstance = instance[tests];
+        if (isThrowable(tests)) {
+            for (const testName in testsInstance) {
+                test(decamelize(testName), t => { t.throws(() => testsInstance[testName]()) });
+            }
+        } else {
+            for (const testName in testsInstance) {
+                test(decamelize(testName), t => { t.truthy(testsInstance[testName]()) });
+            }
+        }
+    }
+})();

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -50,6 +50,10 @@ function unpackToString128(lo: number, hi: number): string {
   return `0x${ (unpackToString64(hi) + unpackToString64(lo)).padStart(32, '0') }`;
 }
 
+function unpackToString256(lo1: number, lo2: number, hi1: number, hi2: number): string {
+  return `0x${ (unpackToString64(hi2) + unpackToString64(hi1) + unpackToString64(lo2) + unpackToString64(lo1)).padStart(32, '0') }`;
+}
+
 function getString(ptr: number, buffer: ArrayBuffer): string {
   var U16 = new Uint16Array(buffer);
   var U32 = new Uint32Array(buffer);
@@ -95,6 +99,13 @@ function buildImports(name: string, memory: WebAssembly.Memory): ImportEntries {
           console.log(`[u128] ${ getString(msgPtr, buffer) }: ${ unpackToString128(lo, hi) }`);
         } else {
           console.log(`[u128]: ${ unpackToString128(lo, hi) }`);
+        }
+      },
+      logU256Packed(msgPtr: number, lo1: number, lo2: number, hi1: number, hi2: number) {
+        if (msgPtr) {
+          console.log(`[u256] ${ getString(msgPtr, buffer) }: ${ unpackToString256(lo1, lo2, hi1, hi2) }`);
+        } else {
+          console.log(`[u256]: ${ unpackToString256(lo1, lo2, hi1, hi2)}`)
         }
       }
     }


### PR DESCRIPTION
Implement `fromBytes` and `toString` for `u256`, as well as some other methods required to implement those two. Also add some tests for `u256`.