### PR TITLE
fix: properly expose safe integer types

### DIFF
--- a/assembly/__tests__/safe_u128.spec.as.ts
+++ b/assembly/__tests__/safe_u128.spec.as.ts
@@ -1,4 +1,5 @@
-import { u128 } from '../../assembly/integer/safe/u128';
+import { u128Safe as u128  } from '..';
+
 
 describe("Basic operations", () => {
   it("Should add two numbers 1", () => {

--- a/assembly/integer/index.ts
+++ b/assembly/integer/index.ts
@@ -1,2 +1,3 @@
 export * from "./u128";
 export * from "./u256";
+export * from "./safe";

--- a/assembly/integer/safe/index.ts
+++ b/assembly/integer/safe/index.ts
@@ -1,0 +1,6 @@
+// export * from "./u64";
+export * from "./i128";
+export * from "./i256";
+// export * from "./u64";
+export * from "./u128";
+export * from "./u256";

--- a/assembly/integer/safe/u128.ts
+++ b/assembly/integer/safe/u128.ts
@@ -275,4 +275,4 @@ class u128 extends U128 {
   }
 }
 
-export {u128 as u128Safe}
+export { u128 as u128Safe };

--- a/assembly/integer/safe/u128.ts
+++ b/assembly/integer/safe/u128.ts
@@ -1,4 +1,4 @@
-import { u256 } from './u256';
+import { u256Safe as u256 } from './u256';
 import { i128 } from './i128';
 import { i256 } from './i256';
 import { u128 as U128 } from '../u128';
@@ -14,7 +14,7 @@ import { isPowerOverflow128, atou128 } from '../../utils';
 // declare function logF64(v: f64): void;
 
 // export namespace safe {
-export class u128 extends U128 {
+class u128 extends U128 {
 
   @inline static get Zero(): u128 { return new u128(); }
   @inline static get One():  u128 { return new u128(1); }
@@ -274,3 +274,5 @@ export class u128 extends U128 {
     return new u128(this.lo, this.hi);
   }
 }
+
+export {u128 as u128Safe}

--- a/assembly/integer/safe/u256.ts
+++ b/assembly/integer/safe/u256.ts
@@ -1,5 +1,7 @@
 import { u256 as U256 } from '../u256';
 
-export class u256 extends U256 {
+class u256 extends U256 {
   // TODO override add, sub, inc, dec, mul, div, rem operators
 }
+
+export { u256 as u256Safe };

--- a/assembly/integer/u128.ts
+++ b/assembly/integer/u128.ts
@@ -902,7 +902,6 @@ export class u128 {
   * Return copy of current 128-bit value
   * @returns 128-bit unsigned integer
   */
-  @inline
   clone(): u128 {
     return new u128(this.lo, this.hi);
   }

--- a/assembly/integer/u256.ts
+++ b/assembly/integer/u256.ts
@@ -605,7 +605,6 @@ export class u256 {
     return result;
   }
 
-  @inline
   clone(): u256 {
     return new u256(this.lo1, this.lo2, this.hi1, this.hi2);
   }


### PR DESCRIPTION
Also remove inlining from clone method as this led to a compiler warning about virtual methods not being inlined.
