### PR TITLE
Add safe u256 add and sub

### DIFF
--- a/assembly/__tests__/safe_u256.spec.ts
+++ b/assembly/__tests__/safe_u256.spec.ts
@@ -1,0 +1,159 @@
+import { u256Safe } from "../integer/safe/u256";
+
+describe("Basic Operations", () => {
+  describe("ADD", () => {
+    it("Should add [1, 0, 0, 0] and [max, 0, 0, 0]", () => {
+      var a = u256Safe.One;
+      var b = new u256Safe(u64.MAX_VALUE, 0, 0, 0);
+      var r = new u256Safe(0, 1, 0, 0);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add [1, 0, 0, 0] and [max, max, 0, 0]", () => {
+      var a = u256Safe.One;
+      var b = new u256Safe(u64.MAX_VALUE, u64.MAX_VALUE, 0, 0);
+      var r = new u256Safe(0, 0, 1, 0);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add [1, 0, 0, 0] and [max, max, max, 0]", () => {
+      var a = u256Safe.One;
+      var b = new u256Safe(u64.MAX_VALUE, u64.MAX_VALUE, u64.MAX_VALUE, 0);
+      var r = new u256Safe(0, 0, 0, 1);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add [1, 1, 1, 1] and [max - 1, max - 1, max - 1, max - 1]", () => {
+      const one: u64 = 1;
+      const pre = u64.MAX_VALUE - 1;
+      var a = new u256Safe(one, one, one, one);
+      var b = new u256Safe(pre, pre, pre, pre);
+      var r = u256Safe.Max;
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add two numbers 1", () => {
+      var a = u256Safe.from(23489);
+      var b = u256Safe.from(1234);
+      var r = u256Safe.from(24723);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add two numbers 2", () => {
+      var a = u256Safe.from(43545453452452452);
+      var b = u256Safe.from(1);
+      var r = u256Safe.from(43545453452452453);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+    it("Should add two numbers 3", () => {
+      var a = new u256Safe(6064648183073788001, 18412591705276258226, 18446744073709551615, 9223372036854775807);
+      var b = new u256Safe(3061651127733543934, 42442096056813094);
+      var r = new u256Safe(9126299310807331935, 8289727623519704, 0, 9223372036854775808);
+      expect(a + b).toStrictEqual(r);
+      expect(b + a).toStrictEqual(r);
+    });
+  });
+  describe("SUB", () => {
+    it("Should sub one minus one", () => {
+      var a = u256Safe.One;
+      var b = a;
+      var r = u256Safe.Zero;
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub [2, 2, 2, 2] and [1, 1, 1, 1]", () => {
+      var a = new u256Safe(2, 2, 2, 2);
+      var b = new u256Safe(1, 1, 1, 1);
+      var r = b;
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub [max, max, max, max] and [1, 2, 3, 4]", () => {
+      const max = u64.MAX_VALUE;
+      var a = u256Safe.Max;
+      var b = new u256Safe(1, 2, 3, 4);
+      var r = new u256Safe(max - 1, max - 2, max - 3, max - 4);
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub [max, max, max, max] and [1, 0, 0, 0]", () => {
+      const max = u64.MAX_VALUE;
+      var a = u256Safe.Max;
+      var b = u256Safe.One;
+      var r = new u256Safe(max - 1, max, max, max);
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub two numbers 1", () => {
+      var a = u256Safe.from(23489);
+      var b = u256Safe.from(1234);
+      var r = u256Safe.from(22255);
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub two numbers 2", () => {
+      var a = u256Safe.from(43545453452452453);
+      var b = u256Safe.from(1);
+      var r = u256Safe.from(43545453452452452);
+      expect(a - b).toStrictEqual(r);
+    });
+    it("Should sub two numbers 3", () => {
+      var a = new u256Safe(6064648183073788001, 18412591705276258226, 18446744073709551615, 9223372036854775807);
+      var b = new u256Safe(3061651127733543934, 42442096056813094);
+      var r = new u256Safe(3002997055340244067, 18370149609219445132, 18446744073709551615, 9223372036854775807);
+      expect(a - b).toStrictEqual(r);
+    });
+  });
+});
+
+describe("Overflow Underflow Throwable", () => {
+  describe("ADD", () => {
+    it("Should throw when add two numbers 1", () => {
+      expect(() => {
+        var a = u256Safe.One;
+        var b = u256Safe.Max;
+        !(a + b);
+      }).toThrow();
+    });
+
+    it("Should throw when add two numbers 2", () => {
+      expect(() => {
+        var a = u256Safe.Max;
+        var b = u256Safe.One;
+        !(a + b);
+      }).toThrow();
+    });
+
+    it("Should throw when add two numbers 3", () => {
+      expect(() => {
+        var a = u256Safe.from(-2);
+        var b = new u256Safe(2);
+        !(a + b);
+      }).toThrow();
+    });
+  });
+  /* -------------------------------------------------------------------------- */
+  /*                                SUB OVERFLOW                                */
+  /* -------------------------------------------------------------------------- */
+  describe("SUB", () => {
+    it("Should throw when subtract two numbers 1", () => {
+      expect(() => {
+        var a = u256Safe.Zero;
+        var b = u256Safe.Max;
+        !(a - b);
+      }).toThrow();
+    });
+
+    it("Should throw when subtract two numbers 2", () => {
+      expect(() => {
+        var a = u256Safe.from(-2);
+        var b = u256Safe.Max;
+        !(a - b);
+      }).toThrow();
+    });
+
+    it("Should throw when subtract two numbers 3", () => {
+      expect(() => {
+        var a = u256Safe.Zero;
+        var b = u256Safe.One;
+        !(a - b);
+      }).toThrow();
+    });
+  });
+});

--- a/assembly/__tests__/safe_u256.spec.ts
+++ b/assembly/__tests__/safe_u256.spec.ts
@@ -32,6 +32,12 @@ describe("Basic Operations", () => {
       expect(a + b).toStrictEqual(r);
       expect(b + a).toStrictEqual(r);
     });
+    it("Should test carry and lo2 equality", () => {
+      var a = new u256Safe(u64.MAX_VALUE, 1, 0, 0);
+      var b = new u256Safe(1, 0, 0, 0);
+      var r = new u256Safe(0, 2, 0, 0);
+      expect(a + b).toStrictEqual(r);
+    });
     it("Should add two numbers 1", () => {
       var a = u256Safe.from(23489);
       var b = u256Safe.from(1234);

--- a/assembly/integer/safe/u256.ts
+++ b/assembly/integer/safe/u256.ts
@@ -1,7 +1,151 @@
+import { u128Safe as u128 } from './u128';
+import { u128 as U128 } from '../u128';
 import { u256 as U256 } from '../u256';
 
 class u256 extends U256 {
-  // TODO override add, sub, inc, dec, mul, div, rem operators
+  @inline static get Zero(): u256 {
+    return new u256();
+  }
+  @inline static get One(): u256 {
+    return new u256(1);
+  }
+  @inline static get Min(): u256 {
+    return new u256();
+  }
+  @inline static get Max(): u256 {
+    return new u256(-1, -1, -1, -1);
+  }
+
+  @inline
+  static fromU256(value: u256): u256 {
+    return changetype<u256>(U256.fromU256(value));
+  }
+
+  @inline
+  static fromU128(value: u128): u256 {
+    return changetype<u256>(U256.fromU128(value));
+  }
+
+  @inline
+  static fromI64(value: i64): u256 {
+    return changetype<u256>(U256.fromI64(value));
+  }
+
+  @inline
+  static fromU64(value: u64): u256 {
+    return changetype<u256>(U256.fromU64(value));
+  }
+
+  @inline
+  static fromF64(value: f64): u256 {
+    return changetype<u256>(U256.fromF64(value));
+  }
+
+  @inline
+  static fromF32(value: f32): u256 {
+    return changetype<u256>(U256.fromF32(value));
+  }
+
+  @inline
+  static fromI32(value: i32): u256 {
+    return changetype<u256>(U256.fromI32(value));
+  }
+
+  @inline
+  static fromU32(value: u32): u256 {
+    return changetype<u256>(U256.fromU32(value));
+  }
+
+  @inline
+  static fromBytes<T>(array: T, bigEndian: bool = false): u256 {
+    return changetype<u256>(U256.fromBytes<T>(array, bigEndian));
+  }
+
+  @inline
+  static fromBytesLE(array: u8[]): u256 {
+    return changetype<u256>(U256.fromBytesLE(array));
+  }
+
+  @inline
+  static fromBytesBE(array: u8[]): u256 {
+    return changetype<u256>(U256.fromBytesBE(array));
+  }
+
+  @inline
+  static fromUint8ArrayLE(array: Uint8Array): u256 {
+    return changetype<u256>(U256.fromUint8ArrayLE(array));
+  }
+
+  @inline
+  static fromUint8ArrayBE(array: Uint8Array): u256 {
+    return changetype<u256>(U256.fromUint8ArrayBE(array));
+  }
+
+  @inline
+  static from<T>(value: T): u256 {
+         if (value instanceof bool)       return u256.fromU64(<u64>value);
+    else if (value instanceof i8)         return u256.fromI64(<i64>value);
+    else if (value instanceof u8)         return u256.fromU64(<u64>value);
+    else if (value instanceof i16)        return u256.fromI64(<i64>value);
+    else if (value instanceof u16)        return u256.fromU64(<u64>value);
+    else if (value instanceof i32)        return u256.fromI64(<i64>value);
+    else if (value instanceof u32)        return u256.fromU64(<u64>value);
+    else if (value instanceof i64)        return u256.fromI64(<i64>value);
+    else if (value instanceof u64)        return u256.fromU64(<u64>value);
+    else if (value instanceof f32)        return u256.fromF64(<f64>value);
+    else if (value instanceof f64)        return u256.fromF64(<f64>value);
+    else if (value instanceof u128)       return u256.fromU128(<u128>value);
+    else if (value instanceof U128)       return u256.fromU128(<U128>value);
+    else if (value instanceof U256)       return u256.fromU256(<U256>value);
+    else if (value instanceof u256)       return u256.fromU256(<u256>value);
+    else if (value instanceof u8[])       return u256.fromBytes(<u8[]>value);
+    else if (value instanceof Uint8Array) return u256.fromBytes(<Uint8Array>value);
+    else throw new TypeError("Unsupported generic type");
+  }
+
+  @operator("+")
+  static add(a: u256, b: u256): u256 {
+    var lo1a = a.lo1,
+        lo2a = a.lo2,
+        hi1a = a.hi1,
+        hi2a = a.hi2;
+
+    var lo1b = b.lo1,
+        lo2b = b.lo2,
+        hi1b = b.hi1,
+        hi2b = b.hi2;
+
+    // Addition for the lowest segment
+    var lo1 = lo1a + lo1b;
+    var cy = u64(lo1 < lo1a); // Detect carry
+
+    // Addition for the second lowest segment with carry
+    var lo2 = lo2a + lo2b + cy;
+    cy = u64(lo2 < lo2a || (cy != 0 && lo2 <= lo2b)); // Update carry
+
+    // Addition for the second highest segment with carry
+    var hi1 = hi1a + hi1b + cy;
+    cy = u64(hi1 < hi1a || (cy != 0 && hi1 <= hi1b)); // Update carry
+
+    // Addition for the highest segment with carry
+    var hi2 = hi2a + hi2b + cy;
+
+    // Overflow detection after adding carry to the highest segment
+    // In a 'safe' implementation, an overflow can be detected if the final carry would exceed the bounds of u256,
+    // which means an addition that causes the highest segment to overflow.
+    // However, standard unsigned integer behavior would wrap around, so this step depends on the intended behavior:
+    if (hi2 < hi2a || (cy != 0 && hi2 <= hi2b)) {
+        throw new RangeError("Overflow during addition");
+    }
+
+    return new u256(lo1, lo2, hi1, hi2);
+  }
+
+  @operator("-")
+  static sub(a: u256, b: u256): u256 {
+    if (a < b) throw new RangeError("Underflow during subtraction");
+    return changetype<u256>(U256.sub(changetype<U256>(a), changetype<U256>(b)));
+  }
 }
 
 export { u256 as u256Safe };

--- a/assembly/integer/safe/u256.ts
+++ b/assembly/integer/safe/u256.ts
@@ -121,11 +121,11 @@ class u256 extends U256 {
 
     // Addition for the second lowest segment with carry
     var lo2 = lo2a + lo2b + cy;
-    cy = u64(lo2 < lo2a || (cy != 0 && lo2 <= lo2b)); // Update carry
+    cy = u64(lo2 < lo2a || (cy == 1 && lo2 == lo2a)); // Update carry
 
     // Addition for the second highest segment with carry
     var hi1 = hi1a + hi1b + cy;
-    cy = u64(hi1 < hi1a || (cy != 0 && hi1 <= hi1b)); // Update carry
+    cy = u64(hi1 < hi1a || (cy == 1 && hi1 == hi1a)); // Update carry
 
     // Addition for the highest segment with carry
     var hi2 = hi2a + hi2b + cy;
@@ -134,7 +134,7 @@ class u256 extends U256 {
     // In a 'safe' implementation, an overflow can be detected if the final carry would exceed the bounds of u256,
     // which means an addition that causes the highest segment to overflow.
     // However, standard unsigned integer behavior would wrap around, so this step depends on the intended behavior:
-    if (hi2 < hi2a || (cy != 0 && hi2 <= hi2b)) {
+    if (hi2 < hi2a || (cy == 1 && hi2 == hi2a)) {
         throw new RangeError("Overflow during addition");
     }
 


### PR DESCRIPTION
This PR introduces some bases for the safe u256 type:
- `from` methods to create a safe u256 from signed and unsigned numbers, byte arrays...
- `add` method to add two safe u256 numbers
- `sub` method to subtract two safe u256 numbers

This PR also includes tests for the new methods.

I tried to follow the existing code style and conventions, but please let me know if I missed something.
